### PR TITLE
Add basic site templates and contact form

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,15 @@
 # Unico Consult
 
-This project is a basic Django setup. It includes separate directories for frontend templates, an admin portal, and static assets.
+This repository provides simple HTML templates and a lightweight Python server.
 
-- `templates/` holds all HTML templates for the frontend.
-- `admin_portal/` contains files for the admin interface.
-- `static/` stores static resources like CSS and JavaScript.
+- `templates/` contains the website pages including the home page, services, team, testimonials and contact form.
+- `static/` contains a small CSS stylesheet.
+- `server.py` runs a minimal HTTP server that stores contact form submissions in `contact_messages.json` and attempts to email them using SMTP settings from the environment.
 
+Run the server with:
+
+```bash
+python3 server.py
+```
+
+Then open `http://localhost:8000/index.html` in your browser.

--- a/server.py
+++ b/server.py
@@ -1,0 +1,60 @@
+import http.server
+import json
+import os
+import smtplib
+from email.message import EmailMessage
+from urllib.parse import parse_qs
+
+CONTACTS_FILE = 'contact_messages.json'
+
+class RequestHandler(http.server.SimpleHTTPRequestHandler):
+    def do_POST(self):
+        if self.path == '/contact':
+            length = int(self.headers.get('Content-Length', 0))
+            body = self.rfile.read(length).decode()
+            data = parse_qs(body)
+            entry = {k: v[0] for k, v in data.items()}
+
+            messages = []
+            if os.path.exists(CONTACTS_FILE):
+                with open(CONTACTS_FILE, 'r') as f:
+                    try:
+                        messages = json.load(f)
+                    except json.JSONDecodeError:
+                        messages = []
+            messages.append(entry)
+            with open(CONTACTS_FILE, 'w') as f:
+                json.dump(messages, f, indent=2)
+
+            # send email
+            try:
+                msg = EmailMessage()
+                msg['Subject'] = entry.get('subject', 'Contact Form Submission')
+                msg['From'] = entry.get('email')
+                msg['To'] = os.environ.get('CONTACT_EMAIL_TO', 'admin@example.com')
+                msg.set_content(
+                    f"Name: {entry.get('name')}\n"
+                    f"Email: {entry.get('email')}\n\n"
+                    f"{entry.get('message')}"
+                )
+                host = os.environ.get('SMTP_HOST', 'localhost')
+                port = int(os.environ.get('SMTP_PORT', '25'))
+                with smtplib.SMTP(host, port) as s:
+                    s.send_message(msg)
+            except Exception as exc:
+                print('Failed to send email:', exc)
+
+            self.send_response(303)
+            self.send_header('Location', '/contact.html?success=1')
+            self.end_headers()
+        else:
+            self.send_error(404)
+
+    def log_message(self, format, *args):
+        # quiet logging
+        pass
+
+if __name__ == '__main__':
+    server = http.server.HTTPServer(('0.0.0.0', 8000), RequestHandler)
+    print('Serving on http://0.0.0.0:8000')
+    server.serve_forever()

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,0 +1,6 @@
+body { font-family: Arial, sans-serif; margin: 2em; }
+header { text-align: center; margin-bottom: 2em; }
+.slogan { font-size: 1.2em; margin: 1em 0; }
+.btn { padding: 0.5em 1em; margin-right: 1em; background: #008cba; color: #fff; text-decoration: none; }
+.services, .team { list-style: none; padding: 0; }
+.services li, .team li { margin: 0.5em 0; }

--- a/templates/contact.html
+++ b/templates/contact.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Unico Consult - Contact</title>
+    <link rel="stylesheet" href="/static/styles.css">
+</head>
+<body>
+    <h1>Contact Us</h1>
+    <form action="/contact" method="post">
+        <label>Name: <input type="text" name="name" required></label><br>
+        <label>Email: <input type="email" name="email" required></label><br>
+        <label>Subject: <input type="text" name="subject" required></label><br>
+        <label>Message:<br>
+            <textarea name="message" rows="5" cols="40" required></textarea>
+        </label><br>
+        <button type="submit">Send</button>
+    </form>
+    <a href="/index.html">Back to Home</a>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Unico Consult - Home</title>
+    <link rel="stylesheet" href="/static/styles.css">
+</head>
+<body>
+    <header>
+        <h1>Unico Consult</h1>
+        <p class="slogan">We turn ideas into results.</p>
+        <a class="btn" href="/services.html">Our Services</a>
+        <a class="btn" href="/contact.html">Contact Us</a>
+    </header>
+</body>
+</html>

--- a/templates/services.html
+++ b/templates/services.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Unico Consult - Services</title>
+    <link rel="stylesheet" href="/static/styles.css">
+</head>
+<body>
+    <h1>Our Services</h1>
+    <ul class="services">
+        <li>Consulting</li>
+        <li>Project Management</li>
+        <li>Strategy &amp; Planning</li>
+    </ul>
+    <a href="/index.html">Back to Home</a>
+</body>
+</html>

--- a/templates/team.html
+++ b/templates/team.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Unico Consult - Team</title>
+    <link rel="stylesheet" href="/static/styles.css">
+</head>
+<body>
+    <h1>Our Team</h1>
+    <ul class="team">
+        <li>Otman Hssinoui</li>
+        <li>Farid Saouti</li>
+    </ul>
+    <a href="/index.html">Back to Home</a>
+</body>
+</html>

--- a/templates/testimonials.html
+++ b/templates/testimonials.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Unico Consult - Testimonials</title>
+    <link rel="stylesheet" href="/static/styles.css">
+</head>
+<body>
+    <h1>Testimonials</h1>
+    <blockquote>
+        <p>"Unico Consult helped us achieve our goals!"</p>
+        <cite>- Happy Customer</cite>
+    </blockquote>
+    <blockquote>
+        <p>"Professional and reliable service."</p>
+        <cite>- Another Client</cite>
+    </blockquote>
+    <a href="/index.html">Back to Home</a>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create simple HTML pages for home, services, team, testimonials and contact
- add stylesheet and lightweight Python server
- store contact form submissions and send emails
- update README with usage instructions

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6840b02d4cc0832d977910a0d9344a9c