### PR TITLE
Add SEO metadata support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,4 @@ This project is a basic Django setup. It includes separate directories for front
 - `admin_portal/` contains files for the admin interface.
 - `static/` stores static resources like CSS and JavaScript.
 
+The templates now support SEO metadata and social media links. Default values are defined in `admin_portal/site_settings.py` and can be used by the rendering logic.

--- a/admin_portal/site_settings.py
+++ b/admin_portal/site_settings.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+
+@dataclass
+class SiteSettings:
+    """Stores basic SEO metadata and social links for the site."""
+    seo_title: str = "Default Site Title"
+    seo_description: str = "Default description of the site for SEO purposes."
+    facebook_url: str = "https://facebook.com/your-page"
+    linkedin_url: str = "https://linkedin.com/your-page"
+    twitter_url: str = "https://twitter.com/your-page"
+    instagram_url: str = "https://instagram.com/your-page"

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>{{ seo_title }}</title>
+    <meta name="description" content="{{ seo_description }}">
+</head>
+<body>
+    {% block content %}{% endblock %}
+    <footer>
+        <ul>
+            <li><a href="{{ facebook_url }}">Facebook</a></li>
+            <li><a href="{{ linkedin_url }}">LinkedIn</a></li>
+            <li><a href="{{ twitter_url }}">Twitter</a></li>
+            <li><a href="{{ instagram_url }}">Instagram</a></li>
+        </ul>
+    </footer>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Welcome to Unico Consult</h1>
+<p>Your one-stop consulting solution.</p>
+{% endblock %}


### PR DESCRIPTION
## Summary
- create `site_settings.py` with SEO fields and social links
- add HTML templates that use the new metadata
- document usage in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840b02d891c832db45a4d7b03de5e7e